### PR TITLE
use `path.sep` to fix empty zip issue in Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-./dest
+dest/

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function (filename) {
 			firstFile = file;
 		}
 
-		var relativePath = file.path.replace(file.cwd + '/', '');
+		var relativePath = file.path.replace(file.cwd + path.sep, '');
 		zip.addFile(relativePath, file.contents);
 	}, function () {
 		if (!firstFile) {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   },
   "devDependencies": {
     "mocha": "*",
-    "gulp": "~3.2.0"
+    "gulp": "~3.3.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -2,12 +2,17 @@
 var assert = require('assert');
 var gutil = require('gulp-util');
 var zip = require('./index');
+var path = require('path');
+
+function fixPath(p) {
+	return p.replace(/\//g, path.sep);
+}
 
 it('should zip files', function (cb) {
 	var stream = zip('test.zip');
 
 	stream.on('data', function (file) {
-		assert.equal(file.path, '~/dev/gulp-zip/test.zip');
+		assert.equal(fixPath(file.path), fixPath('~/dev/gulp-zip/test.zip'));
 		assert.equal(file.relative, 'test.zip');
 		assert(file.contents.length > 0);
 		cb();


### PR DESCRIPTION
fix for https://github.com/sindresorhus/gulp-zip/issues/1
