### PR TITLE
Working directory option for zip packing

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var through = require('through2');
 var chalk = require('chalk');
 var AdmZip = require('adm-zip');
 
-module.exports = function (filename) {
+module.exports = function (filename, cwd) {
 	if (!filename) {
 		throw new gutil.PluginError('gulp-zip', chalk.blue('filename') + ' required');
 	}
@@ -29,6 +29,11 @@ module.exports = function (filename) {
 		}
 
 		var relativePath = file.path.replace(file.cwd + path.sep, '');
+
+		if (cwd) {
+			relativePath = path.relative(cwd, relativePath);
+		}
+
 		zip.addFile(relativePath, file.contents);
 		cb()
 	}, function (cb) {

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@ var assert = require('assert');
 var gutil = require('gulp-util');
 var zip = require('./index');
 var path = require('path');
+var AdmZip = require('adm-zip');
 
 function fixPath(p) {
 	return p.replace(/\//g, path.sep);
@@ -15,6 +16,36 @@ it('should zip files', function (cb) {
 		assert.equal(fixPath(file.path), fixPath('~/dev/gulp-zip/test.zip'));
 		assert.equal(file.relative, 'test.zip');
 		assert(file.contents.length > 0);
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		cwd: '~/dev/gulp-zip',
+		base: '~/dev/gulp-zip/fixture',
+		path: '~/dev/gulp-zip/fixture/fixture.txt',
+		contents: new Buffer('hello world')
+	}));
+
+	stream.write(new gutil.File({
+		cwd: '~/dev/gulp-zip',
+		base: '~/dev/gulp-zip/fixture',
+		path: '~/dev/gulp-zip/fixture/fixture2.txt',
+		contents: new Buffer('hello world 2')
+	}));
+
+	stream.end();
+});
+
+it('should receive working directory', function (cb) {
+	var stream = zip('test.zip', 'fixture');
+
+	stream.on('data', function (file) {
+		var zipFile = new AdmZip(file.contents),
+			entries = zipFile.getEntries();
+
+		assert(entries.length > 0)
+		assert(entries[0].entryName, 'fixture.txt');
+
 		cb();
 	});
 


### PR DESCRIPTION
I've added `cwd` option for setting working directory

Usage:

structure:

```
/build
  /frontpage
    index.html
```

gulp config:

```
gulp.src('build/frontpage/**')
  .pipe(zip('archive.zip'))
  .pipe(gulp.dest('build'));
```

And we get archive with `build` directory in root. On first usage I've expected that root directory in archive would be `frontpage`. That's why I used this option

```
gulp.src('build/frontpage/**')
  .pipe(zip('archive.zip', 'build'))
  .pipe(gulp.dest('build'));
```

Also, we can use `options` object for describing stream's options
