### PR TITLE
fix missed date reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = function (filename) {
 		}
 
 		zip.file(file.relative, file.contents, {
-			date: file.stat.mtime
+			date: file.stat ? file.stat.mtime : new Date()
 		});
 
 		cb();


### PR DESCRIPTION
File object, created directly by "new gutil.File" call, can miss file.stat object ( file.stat set to null by default )
