### PR TITLE
JSZip requires forward slashes to delimit directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,10 @@ module.exports = function (filename) {
 			firstFile = file;
 		}
 
-		zip.file(file.relative, file.contents, {
+		// JSZip requires forward slashes to delimit directories
+		var pathname = file.relative.replace(/\\/g,"/");
+		
+		zip.file(pathname, file.contents, {
 			date: file.stat ? file.stat.mtime : new Date()
 		});
 


### PR DESCRIPTION
JSZip requires forward slashes to delimit directories.

When creating zip archives on windows some programs are unable to open them because the zip files do not contain the right directory entries. (The program I was using is vert.x which uses java.util.zip to unzip things).

JSZip seems to require that when calling zip.file with a relative path the path should use forward slashes as a delimiter (see here http://stuk.github.io/jszip/ - search for 'forward slashes'). I applied this fix and now vert.x is able to unzip the archive as they contain directory entries as well as file entries.
