### PR TITLE
add explicit file read to have valid images

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var gutil = require('gulp-util');
 var through = require('through2');
 var chalk = require('chalk');
 var JSZip = require('jszip');
+var fs = require('fs');
 
 module.exports = function (filename) {
 	if (!filename) {
@@ -30,7 +31,7 @@ module.exports = function (filename) {
 		// Because Windows...
 		var pathname = file.relative.replace(/\\/g, '/');
 
-		zip.file(pathname, file.contents, {
+		zip.file(pathname, fs.readFileSync(pathname), {
 			date: file.stat ? file.stat.mtime : new Date()
 		});
 


### PR DESCRIPTION
Hey,

i had problems with adding images to the archive. These were always not readable after extracting the archive. With adding an explicit file read, it works for me. So i can add images to the archive and there were readable/usable after the extraction.

Maybe it helps :)
