### PR TITLE
Add `createSubFolders` option, default to `true`

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,8 @@ module.exports = function (filename, opts) {
 		var pathname = file.relative.replace(/\\/g, '/');
 
 		zip.file(pathname, file.contents, {
-			date: file.stat ? file.stat.mtime : new Date()
+			date: file.stat ? file.stat.mtime : new Date(),
+			createFolders: true
 		});
 
 		cb();

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "chalk": "^0.4.0",
     "gulp-util": "^2.2.0",
-    "jszip": "^2.3.0",
+    "jszip": "^2.4.0",
     "through2": "^0.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I've got a PR (https://github.com/Stuk/jszip/pull/157) in for JSZip to add a `createSubFolders` option that will fix #29.  This pull request just sends that option (defaulting to true if not provided) along to JSZip in each call to `.file`.
