### PR TITLE
Fix: Folders no longer created

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,14 +32,14 @@ module.exports = function (filename, opts) {
 		// Because Windows...
 		var pathname = file.relative.replace(/\\/g, '/');
         
-        // ensure the corresponding folders are being created by
-        // using the corresponding folder functions.
-        var pathFragments = pathname.split('/');
-        var folderFragments = pathFragments.slice(0, -1);
-        var filename = pathFragments[pathFragments.length - 1];
-        var folder = folderFragments.reduce(function(parent, name) {
-            return parent.folder(name);
-        }, zip);
+		// ensure the corresponding folders are being created by
+		// using the corresponding folder functions.
+		var pathFragments = pathname.split('/');
+		var folderFragments = pathFragments.slice(0, -1);
+		var filename = pathFragments[pathFragments.length - 1];
+		var folder = folderFragments.reduce(function(parent, name) {
+			return parent.folder(name);
+		}, zip);
 
 		folder.file(filename, file.contents, {
 			date: file.stat ? file.stat.mtime : new Date()


### PR DESCRIPTION
jszip has been changed (https://github.com/Stuk/jszip/issues/130) to not automatically create folders anymore in favour of allowing filenames with a slash.
This fixes it by using jszip's folder function.
