### PR TITLE
Support destination directory in the zipfile

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,11 @@ module.exports = function (filename, opts) {
 		// because Windows...
 		var pathname = file.relative.replace(/\\/g, '/');
 
+		// Path to destination directory in the zip file
+		if(typeof opts.dest === "string") {
+			pathname = opts.dest + "/" + pathname;
+		}
+
 		zip.file(pathname, file.contents, {
 			date: file.stat ? file.stat.mtime : new Date(),
 			createFolders: true

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,12 @@ Type: `string`
 Type: `boolean`  
 Default: `true`
 
+##### dest
+
+Type: `string`
+
+Path to destination directory in the zip file.
+
 ##### comment
 
 Type: `string`


### PR DESCRIPTION
I want to add `dest` option for setting destination directory in the zip file

Usage:

```
gulp.src(["apps/app-main/**", "apps/app-chat/**", "apps/app-xxx/**", "modules/**", "package.json", "index.html"])
    .pipe(zip('archive-141203.zip', {dest: "webapp"}))
    .pipe(gulp.dest('release'));
```

output zipfile structure

```
archive-141203.zip/
    webapp/apps/app-main/
    webapp/apps/app-chat/
    webapp/apps/app-xxx/
    webapp/modules/
    webapp/package.json
    webapp/index.html
```

When no `options.dest` parameters , directories, zip files is like:

```
archive-141203.zip/
    apps/app-main/
    apps/app-chat/
    apps/app-xxx/
    modules/
    package.json
    index.html
```

`options.dest` parameter allows `gulp.src` each item , output to the same directory , instead of the root zipfile

In one of our projects , we need to be labeled as a multiple apps zip package , if the compressed file is not the root directory , it will be very messy after decompression . 

So I need to add a parameter `options.dest`

thanks!
