### PR TITLE
Prevent null file.content errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,10 @@ module.exports = function (filename, opts) {
 	var zip = new Yazl.ZipFile();
 
 	return through.obj(function (file, enc, cb) {
+		if(!file.contents){
+			cb();
+			return;
+		}
 		if (file.isStream()) {
 			cb(new gutil.PluginError('gulp-zip', 'Streaming not supported'));
 			return;

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function (filename, opts) {
 	var zip = new Yazl.ZipFile();
 
 	return through.obj(function (file, enc, cb) {
-		if(!file.contents){
+		if (!file.contents) {
 			cb();
 			return;
 		}


### PR DESCRIPTION
Sometimes `file.contents` is `null` and break `Yazl.addBuffer` calls.

Tested with a folder :
- [x] Zipping OK
- [x] Unzipping OK