### PR TITLE
feat: add support for stream mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,11 +18,6 @@ module.exports = function (filename, opts) {
 	var zip = new Yazl.ZipFile();
 
 	return through.obj(function (file, enc, cb) {
-		if (file.isStream()) {
-			cb(new gutil.PluginError('gulp-zip', 'Streaming not supported'));
-			return;
-		}
-
 		if (!firstFile) {
 			firstFile = file;
 		}
@@ -41,11 +36,19 @@ module.exports = function (filename, opts) {
 				mode: file.stat.mode
 			});
 		} else {
-			zip.addBuffer(file.contents, pathname, {
+			var stat = {
 				compress: opts.compress,
 				mtime: file.stat ? file.stat.mtime : new Date(),
 				mode: file.stat ? file.stat.mode : null
-			});
+			};
+
+			if (file.isStream()) {
+				zip.addReadStream(file.contents, pathname, stat);
+			}
+
+			if (file.isBuffer()) {
+				zip.addBuffer(file.contents, pathname, stat);
+			}
 		}
 
 		cb();

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "decompress-unzip": "*",
     "gulp": "*",
     "mocha": "*",
-    "vinyl-assign": "*"
+    "vinyl-assign": "*",
+    "vinyl-file": "^2.0.0"
   }
 }


### PR DESCRIPTION
I could run the extra-added test on a 1.6GB file (with a higher timeout) rather than the small fixture, and tests succeeded. So this should fix #58 , but may need further testing before confirming.