### PR TITLE
Remove gulp-utils module dependency 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,14 @@
 'use strict';
 const path = require('path');
-const gutil = require('gulp-util');
+const Vinyl = require('vinyl');
+const PluginError = require('plugin-error');
 const through = require('through2');
 const Yazl = require('yazl');
 const getStream = require('get-stream');
 
 module.exports = (filename, opts) => {
 	if (!filename) {
-		throw new gutil.PluginError('gulp-zip', '`filename` required');
+		throw new PluginError('gulp-zip', '`filename` required');
 	}
 
 	opts = Object.assign({
@@ -59,7 +60,7 @@ module.exports = (filename, opts) => {
 		}
 
 		getStream.buffer(zip.outputStream).then(data => {
-			this.push(new gutil.File({
+			this.push(new Vinyl({
 				cwd: firstFile.cwd,
 				base: firstFile.base,
 				path: path.join(firstFile.base, filename),

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
   ],
   "dependencies": {
     "get-stream": "^3.0.0",
-    "gulp-util": "^3.0.0",
+    "plugin-error": "^0.1.2",
     "through2": "^2.0.1",
+    "vinyl": "^2.1.0",
     "yazl": "^2.1.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import test from 'ava';
-import gutil from 'gulp-util';
+import Vinyl from 'vinyl';
 import unzip from 'decompress-unzip';
 import vinylAssign from 'vinyl-assign';
 import vinylFile from 'vinyl-file';
@@ -30,7 +30,7 @@ test.cb('should zip files', t => {
 		t.true(file.contents.length > 0);
 	});
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		cwd: __dirname,
 		base: path.join(__dirname, 'fixture'),
 		path: path.join(__dirname, 'fixture/fixture.txt'),
@@ -41,7 +41,7 @@ test.cb('should zip files', t => {
 		}
 	}));
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		cwd: __dirname,
 		base: path.join(__dirname, 'fixture'),
 		path: path.join(__dirname, 'fixture/fixture2.txt'),
@@ -103,7 +103,7 @@ test.cb('should not skip empty directories', t => {
 		t.true(file.contents.length > 0);
 	});
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		cwd: __dirname,
 		base: __dirname,
 		path: path.join(__dirname, 'foo'),


### PR DESCRIPTION
`gulp-utils` [has been deprecated](https://github.com/gulpjs/gulp-util)
And it breaks [gulp  version 4](https://github.com/gulpjs/gulp/issues/2065).
`gulp-utils` module has been replaced with suggested modules.



 ---

Fixes #99 