### PR TITLE
Fix creating unusable ZIP files on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,8 @@ module.exports = (filename, options) => {
 		if (file.isNull() && file.stat && file.stat.isDirectory && file.stat.isDirectory()) {
 			zip.addEmptyDirectory(pathname, {
 				mtime: options.modifiedTime || file.stat.mtime || new Date()
-				// Do *not* pass a mode for a directory, creates platform-dependent zip
-				//   files (zip files created on Windows that cannot be opened on MacOS).
+				// Do *not* pass a mode for a directory, because it creates platform-dependent
+				// ZIP files (ZIP files created on Windows that cannot be opened on macOS).
 				// Re-enable if this PR is resolved: https://github.com/thejoshwolfe/yazl/pull/59
 				// mode: file.stat.mode
 			});

--- a/index.js
+++ b/index.js
@@ -34,10 +34,11 @@ module.exports = (filename, options) => {
 
 		if (file.isNull() && file.stat && file.stat.isDirectory && file.stat.isDirectory()) {
 			zip.addEmptyDirectory(pathname, {
-				mtime: options.modifiedTime || file.stat.mtime || new Date(),
-				// Set executable bit on directories if any other bits are set for that user/group/all
-				// Fixes creating unusable zip files on platforms that do not use an executable bit
-				mode: file.stat.mode | (((file.stat.mode >> 1) | (file.stat.mode >> 2)) & 0o111)
+				mtime: options.modifiedTime || file.stat.mtime || new Date()
+				// Do *not* pass a mode for a directory, creates platform-dependent zip
+				//   files (zip files created on Windows that cannot be opened on MacOS).
+				// Re-enable if this PR is resolved: https://github.com/thejoshwolfe/yazl/pull/59
+				// mode: file.stat.mode
 			});
 		} else {
 			const stat = {

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = (filename, options) => {
 				mtime: options.modifiedTime || file.stat.mtime || new Date(),
 				// Set executable bit on directories if any other bits are set for that user/group/all
 				// Fixes creating unusable zip files on platforms that do not use an executable bit
-				mode: file.stat.mode | (((file.stat.mode >> 1) | (file.stat.mode >> 2)) & 73) // 73 = 0111
+				mode: file.stat.mode | (((file.stat.mode >> 1) | (file.stat.mode >> 2)) & 0o111)
 			});
 		} else {
 			const stat = {

--- a/index.js
+++ b/index.js
@@ -35,7 +35,9 @@ module.exports = (filename, options) => {
 		if (file.isNull() && file.stat && file.stat.isDirectory && file.stat.isDirectory()) {
 			zip.addEmptyDirectory(pathname, {
 				mtime: options.modifiedTime || file.stat.mtime || new Date(),
-				mode: file.stat.mode
+				// Set executable bit on directories if any other bits are set for that user/group/all
+				// Fixes creating unusable zip files on platforms that do not use an executable bit
+				mode: file.stat.mode | (((file.stat.mode >> 1) | (file.stat.mode >> 2)) & 73) // 73 = 0111
 			});
 		} else {
 			const stat = {

--- a/test.js
+++ b/test.js
@@ -73,7 +73,7 @@ test.cb('should zip files (using streams)', t => {
 	});
 
 	unzipper.on('end', () => {
-		t.is(files[0].path, 'fixture/fixture.txt');
+		t.is(path.normalize(files[0].path), path.normalize('fixture/fixture.txt'));
 		t.is(files[0].contents.toString(), 'hello world\n');
 		t.is(files[0].stat.mode, stats.mode);
 		t.end();

--- a/test.js
+++ b/test.js
@@ -97,7 +97,7 @@ test.cb('should not skip empty directories', t => {
 		isDirectory() {
 			return true;
 		},
-		mode: 0o644
+		mode: 0o664
 	};
 
 	unzipper.on('data', file => {
@@ -106,7 +106,7 @@ test.cb('should not skip empty directories', t => {
 
 	unzipper.on('end', () => {
 		t.is(files[0].path, 'foo');
-		t.is(files[0].stat.mode, 0o755);
+		t.is(files[0].stat.mode & 0o777, 0o775);
 		t.end();
 	});
 

--- a/test.js
+++ b/test.js
@@ -96,7 +96,8 @@ test.cb('should not skip empty directories', t => {
 	const stats = {
 		isDirectory() {
 			return true;
-		}
+		},
+		mode: 0o644
 	};
 
 	unzipper.on('data', file => {
@@ -105,6 +106,7 @@ test.cb('should not skip empty directories', t => {
 
 	unzipper.on('end', () => {
 		t.is(files[0].path, 'foo');
+		t.is(files[0].stat.mode, 0o755);
 		t.end();
 	});
 


### PR DESCRIPTION
Fixes #112
Fixes #106 
Fixes #76


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#112: gulp-zip change folder permission,  from 755 to 666](https://issuehunt.io/repos/15377028/issues/112)
- [#106: Can't open zip on Mac OS](https://issuehunt.io/repos/15377028/issues/106)
- [#76: Subdirs in zip have wrong file attributes](https://issuehunt.io/repos/15377028/issues/76)
---
</details>
<!-- /Issuehunt content-->