### PR TITLE
Add support for streaming output with option

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ module.exports = (filename, options) => {
 					data = await getStream.buffer(zip.outputStream, {maxBuffer: BufferConstants.MAX_LENGTH});
 				} catch (error) {
 					if (error instanceof getStream.MaxBufferError) {
-						callback(new PluginError('gulp-zip', 'The output zip file is too big to store in a buffer (larger than Buffer MAX_LENGTH). To output a stream instead, set the gulp-zip buffer option to \'false\'.'));
+						callback(new PluginError('gulp-zip', 'The output ZIP file is too big to store in a buffer (larger than Buffer MAX_LENGTH). To output a stream instead, set the gulp-zip buffer option to `false`.'));
 					} else {
 						callback(error);
 					}

--- a/index.js
+++ b/index.js
@@ -67,17 +67,12 @@ module.exports = (filename, options) => {
 
 		(async () => {
 			let data;
-			if (options.streamOutput) {
-				data = zip.outputStream;
-			} else {
-				try {
-					data = await getStream.buffer(zip.outputStream, {maxBuffer: BufferConstants.MAX_LENGTH});
-				} catch (error) {
-					if (error instanceof getStream.MaxBufferError) {
-						callback(new PluginError('gulp-zip', 'The output zip file is too big to store in a buffer (larger than Buffer MAX_LENGTH). Try using the streamOutput option.'));
-						return;
-					}
-
+			try {
+				data = await getStream.buffer(zip.outputStream, {maxBuffer: BufferConstants.MAX_LENGTH});
+			} catch (error) {
+				if (error instanceof getStream.MaxBufferError) {
+					data = zip.outputStream;
+				} else {
 					callback(error);
 					return;
 				}

--- a/index.js
+++ b/index.js
@@ -72,8 +72,9 @@ module.exports = (filename, options) => {
 				try {
 					data = await getStream.buffer(zip.outputStream);
 				} catch (error) {
-					if (error.code === 'ERR_INVALID_OPT_VALUE') {
+					if (error instanceof RangeError && (!error.code || error.code === 'ERR_INVALID_OPT_VALUE' || error.code === 'ERR_OUT_OF_RANGE')) {
 						callback(new PluginError('gulp-zip', 'The output zip file is too big to store in a buffer (larger than Buffer MAX_LENGTH). Try using the streamOutput option.'));
+						return;
 					}
 
 					callback(error);

--- a/index.js
+++ b/index.js
@@ -78,6 +78,7 @@ module.exports = (filename, options) => {
 					}
 
 					callback(error);
+					return;
 				}
 			}
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const path = require('path');
+const BufferConstants = require('buffer').constants;
 const Vinyl = require('vinyl');
 const PluginError = require('plugin-error');
 const through = require('through2');
@@ -70,9 +71,9 @@ module.exports = (filename, options) => {
 				data = zip.outputStream;
 			} else {
 				try {
-					data = await getStream.buffer(zip.outputStream);
+					data = await getStream.buffer(zip.outputStream, {maxBuffer: BufferConstants.MAX_LENGTH});
 				} catch (error) {
-					if (error instanceof RangeError && (!error.code || error.code === 'ERR_INVALID_OPT_VALUE' || error.code === 'ERR_OUT_OF_RANGE')) {
+					if (error instanceof getStream.MaxBufferError) {
 						callback(new PluginError('gulp-zip', 'The output zip file is too big to store in a buffer (larger than Buffer MAX_LENGTH). Try using the streamOutput option.'));
 						return;
 					}

--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ module.exports = (filename, options) => {
 
 	options = {
 		compress: true,
-		streamOutput: false,
 		...options
 	};
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = (filename, options) => {
 
 	options = {
 		compress: true,
+		buffer: true,
 		...options
 	};
 
@@ -66,15 +67,20 @@ module.exports = (filename, options) => {
 
 		(async () => {
 			let data;
-			try {
-				data = await getStream.buffer(zip.outputStream, {maxBuffer: BufferConstants.MAX_LENGTH});
-			} catch (error) {
-				if (error instanceof getStream.MaxBufferError) {
-					data = zip.outputStream;
-				} else {
-					callback(error);
+			if (options.buffer) {
+				try {
+					data = await getStream.buffer(zip.outputStream, {maxBuffer: BufferConstants.MAX_LENGTH});
+				} catch (error) {
+					if (error instanceof getStream.MaxBufferError) {
+						callback(new PluginError('gulp-zip', 'The output zip file is too big to store in a buffer (larger than Buffer MAX_LENGTH). To output a stream instead, set the gulp-zip buffer option to \'false\'.'));
+					} else {
+						callback(error);
+					}
+
 					return;
 				}
+			} else {
+				data = zip.outputStream;
 			}
 
 			this.push(new Vinyl({

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
 		"ava": "^2.3.0",
 		"decompress-unzip": "^3.0.0",
 		"gulp": "^4.0.2",
-		"unzip-stream": "^0.3.0",
 		"vinyl-assign": "^1.2.1",
 		"vinyl-file": "^3.0.0",
 		"xo": "^0.24.0"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"ava": "^2.3.0",
 		"decompress-unzip": "^3.0.0",
 		"gulp": "^4.0.2",
+		"unzip-stream": "^0.3.0",
 		"vinyl-assign": "^1.2.1",
 		"vinyl-file": "^3.0.0",
 		"xo": "^0.24.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"file"
 	],
 	"dependencies": {
-		"get-stream": "^5.1.0",
+		"get-stream": "^5.2.0",
 		"plugin-error": "^1.0.1",
 		"through2": "^3.0.1",
 		"vinyl": "^2.1.0",

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,4 @@ Default: `true`
 If `true`, the resulting ZIP file contents will be a buffer. Large zip files may not be possible to buffer, depending on the size of [Buffer MAX_LENGTH](https://nodejs.org/api/buffer.html#buffer_buffer_constants_max_length).
 If `false`, the ZIP file contents will be a stream.
 
-Similar to [gulp.src's `buffer` option](https://gulpjs.com/docs/en/api/src/#options).
-
-Tip: set this to `false` to allow creating ZIP files larger than Node's maximum buffer length.
+We use this option instead of relying on [gulp.src's `buffer` option](https://gulpjs.com/docs/en/api/src/#options) because we are mapping many input files to one output file and can't reliably detect what the output mode should be based on the inputs, since Vinyl streams could contain mixed streaming and buffered content.

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ exports.default = () => (
 
 ## API
 
-Supports [streaming mode](https://github.com/gulpjs/gulp/blob/master/docs/API.md#optionsbuffer).
+Supports [streaming mode](https://github.com/gulpjs/gulp/blob/master/docs/API.md#optionsbuffer). The output will switch automatically to streaming mode if the zip size exceeds [the maximum length of a buffer](https://nodejs.org/api/buffer.html#buffer_buffer_constants_max_length).
 
 ### zip(filename, options?)
 
@@ -51,11 +51,3 @@ Default: `undefined`
 Overrides the modification timestamp for all files added to the archive.
 
 Tip: Setting it to the same value across executions enables you to create stable archives that change only when the contents of their entries change, regardless of whether those entries were "touched" or regenerated.
-
-##### streamOutput
-
-Type: `boolean`<br>
-Default: `false`
-
-Whether the Vinyl file should contain a stream instead of a buffer (which is the default).
-Useful for producing large zip files that which may exceed [Node's maximum buffer size](https://nodejs.org/dist/latest/docs/api/buffer.html#buffer_buffer_constants_max_length).

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,8 @@ exports.default = () => (
 
 ## API
 
+Supports [streaming mode](https://github.com/gulpjs/gulp/blob/master/docs/API.md#optionsbuffer).
+
 ### zip(filename, options?)
 
 #### filename

--- a/readme.md
+++ b/readme.md
@@ -61,3 +61,5 @@ If `true`, the resulting ZIP file contents will be a buffer. Large zip files may
 If `false`, the ZIP file contents will be a stream.
 
 Similar to [gulp.src's `buffer` option](https://gulpjs.com/docs/en/api/src/#options).
+
+Tip: set this to `false` to allow creating ZIP files larger than Node's maximum buffer length.

--- a/readme.md
+++ b/readme.md
@@ -26,8 +26,6 @@ exports.default = () => (
 
 ## API
 
-Supports [streaming mode](https://github.com/gulpjs/gulp/blob/master/docs/API.md#optionsbuffer). The output will switch automatically to streaming mode if the zip size exceeds [the maximum length of a buffer](https://nodejs.org/api/buffer.html#buffer_buffer_constants_max_length).
-
 ### zip(filename, options?)
 
 #### filename
@@ -51,3 +49,13 @@ Default: `undefined`
 Overrides the modification timestamp for all files added to the archive.
 
 Tip: Setting it to the same value across executions enables you to create stable archives that change only when the contents of their entries change, regardless of whether those entries were "touched" or regenerated.
+
+##### buffer
+
+Type: `boolean`<br>
+Default: `true`
+
+If `true`, the resulting zip file contents will be a buffer. Large zip files may not be possible to buffer, depending on the size of [Buffer MAX_LENGTH](https://nodejs.org/api/buffer.html#buffer_buffer_constants_max_length).
+If `false`, the zip file contents will be a stream.
+
+Similar to [gulp.src's `buffer` option](https://gulpjs.com/docs/en/api/src/#options).

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ Tip: Setting it to the same value across executions enables you to create stable
 Type: `boolean`<br>
 Default: `true`
 
-If `true`, the resulting zip file contents will be a buffer. Large zip files may not be possible to buffer, depending on the size of [Buffer MAX_LENGTH](https://nodejs.org/api/buffer.html#buffer_buffer_constants_max_length).
-If `false`, the zip file contents will be a stream.
+If `true`, the resulting ZIP file contents will be a buffer. Large zip files may not be possible to buffer, depending on the size of [Buffer MAX_LENGTH](https://nodejs.org/api/buffer.html#buffer_buffer_constants_max_length).
+If `false`, the ZIP file contents will be a stream.
 
 Similar to [gulp.src's `buffer` option](https://gulpjs.com/docs/en/api/src/#options).

--- a/readme.md
+++ b/readme.md
@@ -51,3 +51,11 @@ Default: `undefined`
 Overrides the modification timestamp for all files added to the archive.
 
 Tip: Setting it to the same value across executions enables you to create stable archives that change only when the contents of their entries change, regardless of whether those entries were "touched" or regenerated.
+
+##### streamOutput
+
+Type: `boolean`<br>
+Default: `false`
+
+Whether the Vinyl file should contain a stream instead of a buffer (which is the default).
+Useful for producing large zip files that which may exceed [Node's maximum buffer size](https://nodejs.org/dist/latest/docs/api/buffer.html#buffer_buffer_constants_max_length).

--- a/test.js
+++ b/test.js
@@ -267,7 +267,7 @@ test.cb('should explain buffer size errors', t => {
 	stream.pipe(vinylAssign({extract: true})).pipe(unzipper);
 
 	stream.on('error', error => {
-		t.is(error.message, 'The output zip file is too big to store in a buffer (larger than Buffer MAX_LENGTH). To output a stream instead, set the gulp-zip buffer option to \'false\'.');
+		t.is(error.message, 'The output ZIP file is too big to store in a buffer (larger than Buffer MAX_LENGTH). To output a stream instead, set the gulp-zip buffer option to `false`.');
 		t.end();
 	});
 

--- a/test.js
+++ b/test.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import {randomFillSync} from 'crypto';
 import path from 'path';
 import test from 'ava';
 import Vinyl from 'vinyl';
@@ -245,7 +244,7 @@ test.cb('should produce a stream if requested', t => {
 });
 
 test.cb('should explain buffer size errors', t => {
-	const stream = zip('test.zip');
+	const stream = zip('test.zip', {compress: false});
 	const unzipper = unzip();
 	const stats = fs.statSync(path.join(__dirname, 'fixture/fixture.txt'));
 	stream.pipe(vinylAssign({extract: true})).pipe(unzipper);
@@ -255,10 +254,9 @@ test.cb('should explain buffer size errors', t => {
 		t.end();
 	});
 
-	// Produce some giant random data files, which zipped together should cause the zip
+	// Produce some giant data files, which zipped together should cause the zip
 	// to exceed Buffer MAX_LENGTH without individually doing that
 	const contents = Buffer.alloc((2 ** 30) - 1);
-	randomFillSync(contents);
 	for (let i = 0; i < 3; i++) {
 		const fakeFile = new Vinyl({
 			cwd: __dirname,


### PR DESCRIPTION
This change adds support for streaming output through a new `buffer` option to disable using buffers, which works around buffer size limitations I ran into when the output zip file is larger than [Buffer MAX_LENGTH](https://nodejs.org/api/buffer.html#buffer_buffer_constants_max_length) (1-2GB currently). This change also adds the following user-friendly error message when the buffer size is exceeded during zipping:

> The output zip file is too big to store in a buffer (larger than Buffer MAX_LENGTH). To output a stream instead, set the gulp-zip buffer option to 'false'.

I've added test cases for the message and to make the vinyl file contents are a stream.

I haven't added a test to see if the stream can be successfully read since decompress-unzip unfortunately doesn't support streams. Since the stream used is just the original unbuffered output of yazl I thought the other tests might already cover it?