### PR TITLE
Update dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,9 +20,7 @@ export default function gulpZip(filename, options) {
 	const zip = new Yazl.ZipFile();
 
 	return gulpPlugin('gulp-zip', async file => {
-		if (!firstFile) {
-			firstFile = file;
-		}
+		firstFile ||= file;
 
 		// Because Windows...
 		const pathname = file.relative.replaceAll('\\', '/');

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ export default function gulpZip(filename, options) {
 	const zip = new Yazl.ZipFile();
 
 	return gulpPlugin('gulp-zip', async file => {
-		firstFile ||= file;
+		firstFile ??= file;
 
 		// Because Windows...
 		const pathname = file.relative.replaceAll('\\', '/');

--- a/package.json
+++ b/package.json
@@ -31,19 +31,20 @@
 		"file"
 	],
 	"dependencies": {
-		"get-stream": "^8.0.1",
-		"gulp-plugin-extras": "^0.3.0",
+		"get-stream": "^9.0.1",
+		"gulp-plugin-extras": "^1.1.0",
 		"vinyl": "^3.0.0",
 		"yazl": "^2.5.1"
 	},
 	"devDependencies": {
-		"ava": "^5.3.1",
+		"ava": "^6.2.0",
 		"decompress-unzip": "^3.0.0",
 		"easy-transform-stream": "^1.0.1",
-		"gulp": "^4.0.2",
+		"gulp": "^5.0.0",
+		"p-event": "^6.0.1",
 		"vinyl-assign": "^1.2.1",
 		"vinyl-file": "^5.0.0",
-		"xo": "^0.56.0"
+		"xo": "^0.60.0"
 	},
 	"peerDependencies": {
 		"gulp": ">=4"


### PR DESCRIPTION
- Changed one bit in the code because of a linting error from `xo`
- Added `p-event` as a direct dependency (I think it was a dependency from `ava`)

I didn't update `decompress-unzip`. Even the latest version seems quite old, maybe it would be better to use another lib instead? It's only used for the tests after all. If you have any suggestion, I could look into it.